### PR TITLE
Getting import to work in python2.7 after `./setup.py install`

### DIFF
--- a/src/pylogic/__init__.py
+++ b/src/pylogic/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
`from pylogic import logic` works now.